### PR TITLE
ebuild for etcd-export version 1.1.  As updates are tagged, simply do…

### DIFF
--- a/ebuild/dev-db/etcd-export/etcd-export-1.1.ebuild
+++ b/ebuild/dev-db/etcd-export/etcd-export-1.1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+# By Jean-Michel Smith, first created 9/21/15
+
+EAPI=5
+
+inherit user git-r3
+
+DESCRIPTION="Expose hardware info using JSON/REST and provide a system HTML Front-End"
+HOMEPAGE="https://github.com/mickep76/peekaboo.git"
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+DEPEND="dev-lang/go"
+
+EGIT_REPO_URI="https://github.com/mickep76/etcd-export.git"
+EGIT_COMMIT="${PV}"
+
+GOPATH="${WORKDIR}/etcd-export-${PV}"
+
+src_compile() {
+	ebegin "Building etcd-export ${PV}"
+	export GOPATH
+	export PATH=${GOPATH}/bin:${PATH}
+	cd ${GOPATH}
+	./build
+	cd
+	eend ${?}
+}
+
+src_install() {
+	ebegin "installing etcd-export ${PV}"
+	dobin ${GOPATH}/bin/etcd-export
+	dobin ${GOPATH}/bin/etcd-import
+	dobin ${GOPATH}/bin/etcd-delete
+	eend ${?}
+}


### PR DESCRIPTION
… a git mv to rename the ebuild with the appropriate version.  For example, when you tag etcd-export v 1.2, git mv ebuild/dev-db/etcd-export/etcd-export-1.1.ebuild to ebuild/dev-db/etcd-export/etcd-export-1.2.ebuild.

The directory structure reflects how the ebuild is to be added to an overlay or portage tree (i.e. within th overlay mkdir -p dev-db/etcd-export and copy the contents of ebuild/dev-db/etcd-export into the directory).